### PR TITLE
Show new-class popup when necessary (#1)

### DIFF
--- a/CommunityPromotionScreen/Src/NewPromotionScreenbyDefault/Classes/NPSBDP_UIArmory_PromotionHero.uc
+++ b/CommunityPromotionScreen/Src/NewPromotionScreenbyDefault/Classes/NPSBDP_UIArmory_PromotionHero.uc
@@ -188,6 +188,13 @@ simulated function PopulateData()
 		}
 	}
 
+	// Display the "soldier has a new class" popup if required (issue #1)
+	if (Unit.bNeedsNewClassPopup)
+	{
+		`HQPRES.UIClassEarned(Unit.GetReference());
+		Unit.bNeedsNewClassPopup = false;  //Prevent from queueing up more of these popups on toggling soldiers.
+	}
+
 	AS_SetRank(rankIcon);
 	AS_SetClass(classIcon);
 	AS_SetFaction(FactionState.GetFactionIcon());


### PR DESCRIPTION
If the promoted unit's `bNeedsNewClassPopup` flag is set, the promotion screen now displays the "soldier has gained a new class" popup. This typically only happens when promoting rookies.

Resolves #1.