### PR TITLE
Support mutually exclusive abilities (#4)

### DIFF
--- a/CommunityPromotionScreen.XCOM_sln
+++ b/CommunityPromotionScreen.XCOM_sln
@@ -3,15 +3,15 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # XCOM ModBuddy Solution File, Format Version 11.00
 VisualStudioVersion = 12.0.21005.1
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{5DAE07AF-E217-45C1-8DE7-FF99D6011E8A}") = "CommunityPromotionScreen", "CommunityPromotionScreen\CommunityPromotionScreen.x2proj", "{27E16B1C-44A5-4518-BE0A-B4E0A73E3343}"
+Project("{5DAE07AF-E217-45C1-8DE7-FF99D6011E8A}") = "CommunityPromotionScreen", "CommunityPromotionScreen\CommunityPromotionScreen.x2proj", "{7206D3A7-2E8B-4241-8BE4-CBE9AA5DD185}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Default|XCOM 2 = Default|XCOM 2
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{27E16B1C-44A5-4518-BE0A-B4E0A73E3343}.Default|XCOM 2.ActiveCfg = Default|XCOM 2
-		{27E16B1C-44A5-4518-BE0A-B4E0A73E3343}.Default|XCOM 2.Build.0 = Default|XCOM 2
+		{7206D3A7-2E8B-4241-8BE4-CBE9AA5DD185}.Default|XCOM 2.ActiveCfg = Default|XCOM 2
+		{7206D3A7-2E8B-4241-8BE4-CBE9AA5DD185}.Default|XCOM 2.Build.0 = Default|XCOM 2
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/CommunityPromotionScreen/CommunityPromotionScreen.x2proj
+++ b/CommunityPromotionScreen/CommunityPromotionScreen.x2proj
@@ -19,6 +19,9 @@
     <Content Include="Config\XComPromotionUIMod.ini">
       <SubType>Content</SubType>
     </Content>
+    <Content Include="Localization\NewPromotionScreenbyDefault.int">
+      <SubType>Content</SubType>
+    </Content>
     <Content Include="ReadMe.txt" />
     <Content Include="ModPreview.jpg" />
     <Content Include="Config\XComEditor.ini" />

--- a/CommunityPromotionScreen/Localization/NewPromotionScreenbyDefault.int
+++ b/CommunityPromotionScreen/Localization/NewPromotionScreenbyDefault.int
@@ -1,0 +1,2 @@
+[NPSBDP_UIArmory_PromotionHero]
+m_strMutuallyExclusive="Mutually exclusive with:"

--- a/CommunityPromotionScreen/Src/NewPromotionScreenbyDefault/Classes/NPSBDP_UIArmory_PromotionHero.uc
+++ b/CommunityPromotionScreen/Src/NewPromotionScreenbyDefault/Classes/NPSBDP_UIArmory_PromotionHero.uc
@@ -694,10 +694,10 @@ function PreviewAbility(int Rank, int Branch)
 				// Start Issue #128
 				foreach AbilityTemplate.PrerequisiteAbilities(PrereqAbilityName)
 				{
-					if (InStr(PrereqAbilityName, class'UIArmory_PromotionHero'.const.MutuallyExclusivePrefix) == 0)
+					if (InStr(PrereqAbilityName, class'UIArmory_PromotionHero'.default.MutuallyExclusivePrefix) == 0)
 					{
 						PreviousAbilityTemplate = AbilityTemplateManager.FindAbilityTemplate(
-							name(Mid(PrereqAbilityName, Len(class'UIArmory_PromotionHero'.const.MutuallyExclusivePrefix))));
+							name(Mid(PrereqAbilityName, Len(class'UIArmory_PromotionHero'.default.MutuallyExclusivePrefix))));
 						if (PreviousAbilityTemplate != none )
 						{
 							if (MutuallyExclusiveNames != "")

--- a/CommunityPromotionScreen/Src/NewPromotionScreenbyDefault/Classes/NPSBDP_UIArmory_PromotionHero.uc
+++ b/CommunityPromotionScreen/Src/NewPromotionScreenbyDefault/Classes/NPSBDP_UIArmory_PromotionHero.uc
@@ -27,6 +27,8 @@ var int Position, MaxPosition;
 
 var int AdjustXOffset;
 
+var localized string m_strMutuallyExclusive;
+
 simulated function OnInit()
 {
 	super.OnInit();
@@ -637,6 +639,8 @@ function PreviewAbility(int Rank, int Branch)
 	local array<SoldierClassAbilityType> AbilityTree;
 	local string AbilityIcon, AbilityName, AbilityDesc, AbilityHint, AbilityCost, CostLabel, APLabel, PrereqAbilityNames;
 	local name PrereqAbilityName;
+	// Variable for Issue #128
+	local string MutuallyExclusiveNames;
 
 	// NPSBDP Patch
 	Branch += Position;
@@ -687,24 +691,48 @@ function PreviewAbility(int Rank, int Branch)
 			{
 				// Look back to the previous rank and check to see if that ability is a prereq for this one
 				// If so, display a message warning the player that there is a prereq
+				// Start Issue #128
 				foreach AbilityTemplate.PrerequisiteAbilities(PrereqAbilityName)
 				{
-					PreviousAbilityTemplate = AbilityTemplateManager.FindAbilityTemplate(PrereqAbilityName);
-					if (PreviousAbilityTemplate != none && !Unit.HasSoldierAbility(PrereqAbilityName))
+					if (InStr(PrereqAbilityName, class'UIArmory_PromotionHero'.const.MutuallyExclusivePrefix) == 0)
 					{
-						if (PrereqAbilityNames != "")
+						PreviousAbilityTemplate = AbilityTemplateManager.FindAbilityTemplate(
+							name(Mid(PrereqAbilityName, Len(class'UIArmory_PromotionHero'.const.MutuallyExclusivePrefix))));
+						if (PreviousAbilityTemplate != none )
 						{
-							PrereqAbilityNames $= ", ";
+							if (MutuallyExclusiveNames != "")
+							{
+								MutuallyExclusiveNames $= ", ";
+							}
+							MutuallyExclusiveNames $= PreviousAbilityTemplate.LocFriendlyName;
 						}
-						PrereqAbilityNames $= PreviousAbilityTemplate.LocFriendlyName;
+					}
+					else
+					{
+						PreviousAbilityTemplate = AbilityTemplateManager.FindAbilityTemplate(PrereqAbilityName);
+						if (PreviousAbilityTemplate != none && !Unit.HasSoldierAbility(PrereqAbilityName))
+						{
+							if (PrereqAbilityNames != "")
+							{
+								PrereqAbilityNames $= ", ";
+							}
+							PrereqAbilityNames $= PreviousAbilityTemplate.LocFriendlyName;
+						}
 					}
 				}
 				PrereqAbilityNames = class'UIUtilities_Text'.static.FormatCommaSeparatedNouns(PrereqAbilityNames);
+				MutuallyExclusiveNames = class'UIUtilities_Text'.static.FormatCommaSeparatedNouns(MutuallyExclusiveNames);
+
+				if (MutuallyExclusiveNames != "")
+				{
+					AbilityDesc = class'UIUtilities_Text'.static.GetColoredText(m_strMutuallyExclusive @ MutuallyExclusiveNames, eUIState_Warning) $ "\n" $ AbilityDesc;
+				}
 
 				if (PrereqAbilityNames != "")
 				{
 					AbilityDesc = class'UIUtilities_Text'.static.GetColoredText(m_strPrereqAbility @ PrereqAbilityNames, eUIState_Warning) $ "\n" $ AbilityDesc;
 				}
+				// End Issue #128
 			}
 		}
 		else


### PR DESCRIPTION
Ability prerequisites that begin with "NOT_" are treated as mutually
exclusive abilities and are displayed as such in the ability preview.

This takes the pull request that Musashi sent to the original NPSBD mod
and applies it to the community version.

Implements #4.