### PR TITLE
Refactor GetAbilityPointCost() and implement issue #10 - ability point cost override

### DIFF
--- a/CommunityPromotionScreen/CommunityPromotionScreen.x2proj
+++ b/CommunityPromotionScreen/CommunityPromotionScreen.x2proj
@@ -7,6 +7,7 @@
     <SteamPublishID>0</SteamPublishID>
     <AssemblyName>CommunityPromotionScreen</AssemblyName>
     <RootNamespace>CommunityPromotionScreen</RootNamespace>
+    <ProjectGuid>{c635fb6f-86cf-466c-963b-32b2a1f0108b}</ProjectGuid>
   </PropertyGroup>
   <ItemGroup>
     <Folder Include="Config\" />


### PR DESCRIPTION
Closes #10

New `GetAbilityPointCost()` is *much* more readable. I've also added a standard CHL-style override event with a tuple that passes ability's position in the skill tree and its template name, along with the calculated ability point cost so far.

I've done some testing and the basegame functionality is preserved in all standard cases, even though technically the new function works differently.

I've opted to not use hardcoded numbers for perk rows and ranks. 