### PR TITLE
Implement issue #22 - override localized perk row name

### DIFF
--- a/CommunityPromotionScreen.XCOM_sln
+++ b/CommunityPromotionScreen.XCOM_sln
@@ -3,15 +3,15 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # XCOM ModBuddy Solution File, Format Version 11.00
 VisualStudioVersion = 12.0.21005.1
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{5DAE07AF-E217-45C1-8DE7-FF99D6011E8A}") = "CommunityPromotionScreen", "CommunityPromotionScreen\CommunityPromotionScreen.x2proj", "{C635FB6F-86CF-466C-963B-32B2A1F0108B}"
+Project("{5DAE07AF-E217-45C1-8DE7-FF99D6011E8A}") = "CommunityPromotionScreen", "CommunityPromotionScreen\CommunityPromotionScreen.x2proj", "{5FA55240-8F4B-4B95-B82F-51BE93EB38B1}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Default|XCOM 2 = Default|XCOM 2
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{C635FB6F-86CF-466C-963B-32B2A1F0108B}.Default|XCOM 2.ActiveCfg = Default|XCOM 2
-		{C635FB6F-86CF-466C-963B-32B2A1F0108B}.Default|XCOM 2.Build.0 = Default|XCOM 2
+		{5FA55240-8F4B-4B95-B82F-51BE93EB38B1}.Default|XCOM 2.ActiveCfg = Default|XCOM 2
+		{5FA55240-8F4B-4B95-B82F-51BE93EB38B1}.Default|XCOM 2.Build.0 = Default|XCOM 2
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Closes #22

I need this functionality for the officers mod, but this will come in handy for any kind of mod that dynamically injects ability rows into soldiers' ability trees.

Tested to be working.