### PR TITLE
Implement issue #25 - fix templar momentum bug

### DIFF
--- a/CommunityPromotionScreen/Src/NewPromotionScreenbyDefault/Classes/X2DownloadableContentInfo_NewPromotionScreenbyDefault.uc
+++ b/CommunityPromotionScreen/Src/NewPromotionScreenbyDefault/Classes/X2DownloadableContentInfo_NewPromotionScreenbyDefault.uc
@@ -1,5 +1,54 @@
 class X2DownloadableContentInfo_NewPromotionScreenbyDefault extends X2DownloadableContentInfo;
 
+static event OnPostTemplatesCreated()
+{
+	// Issue #25
+	FixTemplarMomentumBug();
+}
+
+// Start Issue #25
+static private function FixTemplarMomentumBug()
+{
+	local X2SoldierClassTemplateManager	Mgr;
+	local X2SoldierClassTemplate		Template;	
+	local SoldierClassAbilitySlot		EmptySlot;
+	local SoldierClassAbilitySlot		MomentumSlot;
+	local array<X2DataTemplate>			DataTemplates;
+	local X2DataTemplate				DataTemplate;
+
+	Mgr = class'X2SoldierClassTemplateManager'.static.GetSoldierClassTemplateManager();
+	Mgr.FindDataTemplateAllDifficulties('Templar', DataTemplates);
+	MomentumSlot.AbilityType.AbilityName = 'Momentum';
+
+	foreach DataTemplates(DataTemplate)
+	{
+		Template = X2SoldierClassTemplate(DataTemplate);
+
+		// Requires unprotecting X2SoldierClassTemplate.SoldierRanks
+		if (Template.SoldierRanks.Length != 0 &&
+			Template.SoldierRanks[0].AbilitySlots.Length > 4 &&
+			Template.SoldierRanks[0].AbilitySlots[3] == EmptySlot &&
+			Template.SoldierRanks[0].AbilitySlots[4] == MomentumSlot)
+		{
+			Template.SoldierRanks[0].AbilitySlots[3] = MomentumSlot;
+			Template.SoldierRanks[0].AbilitySlots.Remove(4, 1);
+
+		}
+
+		// Patching SoldierRanks in template instance *should* be enough, 
+		// but let's patch 'default' SoldierRanks as well just to be super duper safe.
+		if (Template.default.SoldierRanks.Length != 0 && 
+			Template.default.SoldierRanks[0].AbilitySlots.Length > 4 &&
+			Template.default.SoldierRanks[0].AbilitySlots[3] == EmptySlot &&
+			Template.default.SoldierRanks[0].AbilitySlots[4] == MomentumSlot)
+		{
+			Template.default.SoldierRanks[0].AbilitySlots[3] = MomentumSlot;
+			Template.default.SoldierRanks[0].AbilitySlots.Remove(4, 1);
+		}
+	}
+}
+// End Issue #25
+
 exec function PSSetXoffsetBG(int AdjustXOffset)
 {
 	local NPSBDP_UIArmory_PromotionHero UI;


### PR DESCRIPTION
Closes #25 

The code is a bit cumbersome, but simple and solid. It makes no assumptions, like Templar soldier class existing, and does one and one thing only: it moves the Momentum ability slot into the empty slot above it, and deletes the resulting empty slot where Momentum used to be. A bit inconvenient that building will now require unprotecting `X2SoldierClassTemplate.SoldierRanks`, but it is what it is.