### PR TITLE
Retain focus on abilities when selected/purchased (#37)

### DIFF
--- a/X2WOTCCommunityPromotionScreen/Src/X2WOTCCommunityPromotionScreen/Classes/CPS_UIArmory_PromotionHero.uc
+++ b/X2WOTCCommunityPromotionScreen/Src/X2WOTCCommunityPromotionScreen/Classes/CPS_UIArmory_PromotionHero.uc
@@ -590,7 +590,6 @@ simulated function bool AttemptScroll(bool Up)
 // This is a copy of `ComfirmAbilityCallback` so that we can inject some
 // hooks into to, because some mods will want to add behaviour around when
 // the player selects/purchases an ability.
-// (It also gives us the opportunity to fix a dumb typo in the function name)
 simulated function ConfirmAbilityCallbackEx(Name Action)
 {
 	local XComGameStateHistory History;
@@ -627,7 +626,9 @@ simulated function ConfirmAbilityCallbackEx(Name Action)
 			// End Issue #37
 		}
 		else
+		{
 			History.CleanupPendingGameState(UpdateState);
+		}
 
 		Movie.Pres.PlayUISound(eSUISound_SoldierPromotion);
 	}


### PR DESCRIPTION
(Originally part of [this LWOTC pull request](https://github.com/long-war-2/lwotc/pull/1041))

We provide our own confirmation callback function for ability selection so that focus is retained for the selected ability when a controller is used.

Note that this custom callback function will also allow us to introduce hooks that mods can use.

Resolves #37.