### PR TITLE
Fix scrollbar position in windowed mode (#19)

### DIFF
--- a/X2WOTCCommunityPromotionScreen/Src/X2WOTCCommunityPromotionScreen/Classes/CPS_UIArmory_PromotionHero.uc
+++ b/X2WOTCCommunityPromotionScreen/Src/X2WOTCCommunityPromotionScreen/Classes/CPS_UIArmory_PromotionHero.uc
@@ -100,11 +100,11 @@ simulated function InitPromotion(StateObjectReference UnitRef, optional bool bIn
 	{
 		if (bHasBrigadierRank)
 		{
-			Scrollbar.SetPosition(-465, 310);
+			Scrollbar.SetPosition(1350, 310);
 		}
 		else
 		{
-			Scrollbar.SetPosition(-550, 310);
+			Scrollbar.SetPosition(1275, 310);
 		}
 		
 		Scrollbar.MC.SetNum("_alpha", 0);
@@ -659,7 +659,6 @@ simulated function RealizeScrollbar()
 		if(Scrollbar == none)
 		{			
 			Scrollbar = Spawn(class'UIScrollbar', self).InitScrollbar();
-			Scrollbar.SetAnchor(class'UIUtilities'.const.ANCHOR_TOP_RIGHT);
 			Scrollbar.SetHeight(450);						
 		}
 		Scrollbar.NotifyValueChange(OnScrollBarChange, 0.0, MaxPosition);


### PR DESCRIPTION
The anchoring of the scrollbar seems to break its position in windowed mode, so this removes the anchor and changes the positions to absolute X values.

Fixes #19.