### PR TITLE
Use listener to set SPARK ability tree titles (#44)

### DIFF
--- a/X2WOTCCommunityPromotionScreen/Localization/X2WOTCCommunityPromotionScreen.chn
+++ b/X2WOTCCommunityPromotionScreen/Localization/X2WOTCCommunityPromotionScreen.chn
@@ -1,8 +1,8 @@
-[Spark X2SoldierClassTemplate]
-AbilityTreeTitles[0]="未来战斗"
-AbilityTreeTitles[1]="战争机器"
-AbilityTreeTitles[2]="XCOM"
-
 [UISL_CPS]
 strDisablePopup = "不要再显示此消息"
 strPopupText = "\n你好, 这是你的Mod <font color='#00ff00'>[WOTC] Community Promotion Screen</font>\n\n我检测到你所使用的Mod <font color='#ff0000'>[WOTC] New Promotion Screen by Default</font>是旧的版本. Mod<font color='#ff0000'>[WOTC] New Promotion Screen by Default</font>仍会生效, 但是你并不需要它\n\n我会代替处理<font color='#ff0000'>[WOTC] New Promotion Screen by Default</font>的一切以及更多,同时兼容其他所需要它的Mod. 因此建议你停用或卸载<font color='#ff0000'>[WOTC] New Promotion Screen by Default</font>"
+
+[X2EventListener_PromotionScreenOverrides]
+SparkAbilityTreeTitles[0]="未来战斗"
+SparkAbilityTreeTitles[1]="战争机器"
+SparkAbilityTreeTitles[2]="XCOM"

--- a/X2WOTCCommunityPromotionScreen/Localization/X2WOTCCommunityPromotionScreen.cht
+++ b/X2WOTCCommunityPromotionScreen/Localization/X2WOTCCommunityPromotionScreen.cht
@@ -1,9 +1,8 @@
-[Spark X2SoldierClassTemplate]
-AbilityTreeTitles[0]="未來戰鬥"
-AbilityTreeTitles[1]="戰爭機器"
-AbilityTreeTitles[2]="XCOM"
-
 [UISL_CPS]
 strDisablePopup = "不要再顯示此消息"
 strPopupText = "\n你好, 這是你的Mod <font color='#005AB5'>[WOTC] Community Promotion Screen</font>\n\n我檢測到你所使用的Mod <font color='#ff0000'>[WOTC] New Promotion Screen by Default</font>是舊的版本.Mod<font color='#ff0000'>[WOTC] New Promotion Screen by Default</font>仍會生效, 但是你並不需要它\n\n我會代替處理<font color='#ff0000'>[WOTC] New Promotion Screen by Default</font>的一切以及更多,同時兼容其他所需要它的Mod. 因此建議你停用或卸載<font color='#ff0000'>[WOTC] New Promotion Screen by Default</font>"
 
+[X2EventListener_PromotionScreenOverrides]
+SparkAbilityTreeTitles[0]="未來戰鬥"
+SparkAbilityTreeTitles[1]="戰爭機器"
+SparkAbilityTreeTitles[2]="XCOM"

--- a/X2WOTCCommunityPromotionScreen/Localization/X2WOTCCommunityPromotionScreen.deu
+++ b/X2WOTCCommunityPromotionScreen/Localization/X2WOTCCommunityPromotionScreen.deu
@@ -1,8 +1,8 @@
-[Spark X2SoldierClassTemplate]
-AbilityTreeTitles[0]="Kampf der Zukunft"
-AbilityTreeTitles[1]="Kriegsmaschine"
-AbilityTreeTitles[2]="XCOM"
-
 [UISL_CPS]
 strDisablePopup = "NICHT WIEDER ZEIGEN"
 strPopupText = "\nHallo, hier spricht eine deiner Modifikationen, <font color='#005AB5'>[WOTC] Community Promotion Screen</font>n\nIch stelle fest das du eine überholte Version verwendest: <font color='#005AB5'>[WOTC] Community Promotion Screen</font>. Diese Version funktioniert weiterhin, aber du brauchst sie nicht.\n\nIch habe alle Funktionen von <font color='#005AB5'>[WOTC] Community Promotion Screen</font> und noch mehr, und alle Modifikationen, die diese alte Version benötigen, funktionieren auch mit mir.\n\nEs ist empfohlen dass du <font color='#005AB5'>[WOTC] Community Promotion Screen</font> deaktivierst oder deinstallierst. Ich übernehme alle ihre Aufgaben."
+
+[X2EventListener_PromotionScreenOverrides]
+SparkAbilityTreeTitles[0]="Kampf der Zukunft"
+SparkAbilityTreeTitles[1]="Kriegsmaschine"
+SparkAbilityTreeTitles[2]="XCOM"

--- a/X2WOTCCommunityPromotionScreen/Localization/X2WOTCCommunityPromotionScreen.esn
+++ b/X2WOTCCommunityPromotionScreen/Localization/X2WOTCCommunityPromotionScreen.esn
@@ -1,8 +1,8 @@
-[Spark X2SoldierClassTemplate]
-AbilityTreeTitles[0]="Combate del futuro"
-AbilityTreeTitles[1]="Máquina de guerra"
-AbilityTreeTitles[2]="XCOM"
-
 [UISL_CPS]
 strDisablePopup = "DESACTIVAR ESTE MENSAJE"
 strPopupText = "\nBienvenido. Éste es tu mod en uso, <font color='#00ff00'>[WOTC] Community Promotion Screen</font>.\n\nVeo que también tienes activada otra versión más antigua: <font color='#ff0000'>[WOTC] New Promotion Screen by Default</font>. Funciona, pero no es necesario.\n\nYo (<font color='#00ff00'>[WOTC] Community Promotion Screen</font>) hago todo lo que <font color='#ff0000'>[WOTC] New Promotion Screen by Default</font> puede y más; por tanto, funciono también con cualquier mod que requiere <font color='#ff0000'>[WOTC] New Promotion Screen by Default</font>.\n\nSe recomienda que desactives o desinstales <font color='#ff0000'>[WOTC] New Promotion Screen by Default</font>. <font color='#00ff00'>[WOTC] Community Promotion Screen</font> ejecutará las misjmas funciones."
+
+[X2EventListener_PromotionScreenOverrides]
+SparkAbilityTreeTitles[0]="Combate del futuro"
+SparkAbilityTreeTitles[1]="Máquina de guerra"
+SparkAbilityTreeTitles[2]="XCOM"

--- a/X2WOTCCommunityPromotionScreen/Localization/X2WOTCCommunityPromotionScreen.fra
+++ b/X2WOTCCommunityPromotionScreen/Localization/X2WOTCCommunityPromotionScreen.fra
@@ -1,8 +1,8 @@
-[Spark X2SoldierClassTemplate]
-AbilityTreeTitles[0]="Combat du futur"
-AbilityTreeTitles[1]="Machine de guerre"
-AbilityTreeTitles[2]="XCOM"
-
 [UISL_CPS]
 strDisablePopup = "NE PLUS AFFICHER CE MESSAGE"
 strPopupText = "\nBonjour, c'est votre mod, <font color='#005AB5'>[WOTC] Community Promotion Screen</font>.\n\nJe vois que vous utilisez une version désuète: <font color='#ff0000'>[WOTC] New Promotion Screen by Default</font>. Elle fonctionne, mais vous n'en avez plus besoin.\n\nJe fais tout ce que <font color='#ff0000'>[WOTC] New Promotion Screen by Default</font> fait et plus encore et je fonctionne avec avec tous les mods qui en ont besoin.\n\nJe vous recommande de désactiver ou désinstaller <font color='#ff0000'>[WOTC] New Promotion Screen by Default</font>. Je prendrai en charge ses fonctions."
+
+[X2EventListener_PromotionScreenOverrides]
+SparkAbilityTreeTitles[0]="Combat du futur"
+SparkAbilityTreeTitles[1]="Machine de guerre"
+SparkAbilityTreeTitles[2]="XCOM"

--- a/X2WOTCCommunityPromotionScreen/Localization/X2WOTCCommunityPromotionScreen.int
+++ b/X2WOTCCommunityPromotionScreen/Localization/X2WOTCCommunityPromotionScreen.int
@@ -26,3 +26,8 @@ DISABLE_NEWCLASS_POPUPS_Tips = "Normally a popup is displayed each time a rookie
 
 DISABLE_COMINT_POPUPS_Label = "Disable Combat Intelligence tutorial popup"
 DISABLE_COMINT_POPUPS_Tips = "Normally a popup is displayed when you enter the promotion screen of a high Combat Intelligence soldier for the first time in a campaign. You can disable this popup here."
+
+[X2EventListener_PromotionScreenOverrides]
+SparkAbilityTreeTitles[0]="Future Combat"
+SparkAbilityTreeTitles[1]="War Machine"
+SparkAbilityTreeTitles[2]="XCOM"

--- a/X2WOTCCommunityPromotionScreen/Localization/X2WOTCCommunityPromotionScreen.ita
+++ b/X2WOTCCommunityPromotionScreen/Localization/X2WOTCCommunityPromotionScreen.ita
@@ -1,8 +1,8 @@
-[Spark X2SoldierClassTemplate]
-AbilityTreeTitles[0]="Guerra del futuro"
-AbilityTreeTitles[1]="Macchina da guerra"
-AbilityTreeTitles[2]="XCOM"
-
 [UISL_CPS]
 strDisablePopup = "NON MOSTRARE DI NUOVO"
 strPopupText = "\nCiao, questo è un messaggio della mod <font color='#00ff00'>[WOTC] Community Promotion Screen</font>.\n\nStai usando una versione obsoleta di questa mod, <font color='#ff0000'>[WOTC] New Promotion Screen by Default</font>. La cosa non creerà alcun conflitto, ma non è necessario tenerla attiva.\n\n[WOTC] Community Promotion Screen ha tutte le funzionalità di <font color='#ff0000'>[WOTC] New Promotion Screen by Default</font> ed oltre, e funziona con tutte le mod che la indicano come mod necessaria.\n\nÈ consigliato disinstallare o disabilitare <font color='#ff0000'>[WOTC] New Promotion Screen by Default</font>."
+
+[X2EventListener_PromotionScreenOverrides]
+SparkAbilityTreeTitles[0]="Guerra del futuro"
+SparkAbilityTreeTitles[1]="Macchina da guerra"
+SparkAbilityTreeTitles[2]="XCOM"

--- a/X2WOTCCommunityPromotionScreen/Localization/X2WOTCCommunityPromotionScreen.jpn
+++ b/X2WOTCCommunityPromotionScreen/Localization/X2WOTCCommunityPromotionScreen.jpn
@@ -1,8 +1,8 @@
-[Spark X2SoldierClassTemplate]
-AbilityTreeTitles[0]="未来の戦闘"
-AbilityTreeTitles[1]="ウォー・マシーン"
-AbilityTreeTitles[2]="XCOM"
-
 [UISL_CPS]
 strDisablePopup = "次回から表示しない"
 strPopupText = "\nこんにちは、<font color='#00ff00'>[WOTC] Community Promotion Screen</font>です。\n\n<font color='#ff0000'>[WOTC] New Promotion Screen by Default</font>を使用しているようですが、<font color='#00ff00'>[WOTC] Community Promotion Screen</font>は<font color='#ff0000'>[WOTC] New Promotion Screen by Default</font>の上位互換となっており、かつ<font color='#ff0000'>[WOTC] New Promotion Screen by Default</font>が前提とするMODにも互換性がありますので、<font color='#ff0000'>[WOTC] New Promotion Screen by Default</font>を無効化、あるいはアンインストールすることをお勧めします。"
+
+[X2EventListener_PromotionScreenOverrides]
+SparkAbilityTreeTitles[0]="未来の戦闘"
+SparkAbilityTreeTitles[1]="ウォー・マシーン"
+SparkAbilityTreeTitles[2]="XCOM"

--- a/X2WOTCCommunityPromotionScreen/Localization/X2WOTCCommunityPromotionScreen.kor
+++ b/X2WOTCCommunityPromotionScreen/Localization/X2WOTCCommunityPromotionScreen.kor
@@ -1,8 +1,8 @@
-[Spark X2SoldierClassTemplate]
-AbilityTreeTitles[0]="미래 전투"
-AbilityTreeTitles[1]="워머신"
-AbilityTreeTitles[2]="XCOM"
-
 [UISL_CPS]
 strDisablePopup = "다시 표시하지 않음."
 strPopupText = "\n안녕하세요 이것은 당신이 설치한 모드 <font color='#00ff00'>[WOTC] Community Promotion Screen</font> 입니다.\n\n구버전인 <font color='#ff0000'>[WOTC] New Promotion Screen by Default</font>를 사용하고 있습니다. 작동은 하지만, 필요하지 않습니다.\n\n이는 <font color='#ff0000'>[WOTC] New Promotion Screen by Default</font>가 하는 일이나 그 이상의 일을 하고 있으며, 그것을 필요로 하는 모든 모드와 함께 작동합니다.\n\n<font color='#ff0000'>[WOTC] New Promotion Screen by Default</font>를 비활성화하거나 제거하는 것이 좋습니다."
+
+[X2EventListener_PromotionScreenOverrides]
+SparkAbilityTreeTitles[0]="미래 전투"
+SparkAbilityTreeTitles[1]="워머신"
+SparkAbilityTreeTitles[2]="XCOM"

--- a/X2WOTCCommunityPromotionScreen/Localization/X2WOTCCommunityPromotionScreen.pol
+++ b/X2WOTCCommunityPromotionScreen/Localization/X2WOTCCommunityPromotionScreen.pol
@@ -1,8 +1,8 @@
-[Spark X2SoldierClassTemplate]
-AbilityTreeTitles[0]="Walka przyszłości"
-AbilityTreeTitles[1]="Machina bojowa"
-AbilityTreeTitles[2]="XCOM"
-
 [UISL_CPS]
 strDisablePopup = "Wyłącz tę wiadomość"
 strPopupText = "\nCześć, tu twój mod <font color='#00ff00'>[WOTC] Community Promotion Screen</font>.\n\nWidzę że używasz przestarzałą wersję: <font color='#ff0000'>[WOTC] New Promotion Screen by Default</font>.\n\nOna działa, ale jej nie potrzebujesz. Robię wszystko co <font color='#ff0000'>[WOTC] New Promotion Screen by Default</font> robi I więcej, i działam z wszystkimi wymaganymi modami.\n\nZalecam aby zdezaktywować lub usunąć <font color='#ff0000'>[WOTC] New Promotion Screen by Default</font>, gdyż przejmę jej funkcje."
+
+[X2EventListener_PromotionScreenOverrides]
+SparkAbilityTreeTitles[0]="Walka przyszłości"
+SparkAbilityTreeTitles[1]="Machina bojowa"
+SparkAbilityTreeTitles[2]="XCOM"

--- a/X2WOTCCommunityPromotionScreen/Localization/X2WOTCCommunityPromotionScreen.rus
+++ b/X2WOTCCommunityPromotionScreen/Localization/X2WOTCCommunityPromotionScreen.rus
@@ -1,8 +1,8 @@
-[Spark X2SoldierClassTemplate]
-AbilityTreeTitles[0]="Битва будущего"
-AbilityTreeTitles[1]="Боевая машина"
-AbilityTreeTitles[2]="XCOM"
-
 [UISL_CPS]
 strDisablePopup = "ОТКЛЮЧИТЬ ЭТО СООБЩЕНИЕ"
 strPopupText = "\nПривет, это ваш мод - <font color='#005AB5'>[WOTC] Community Promotion Screen</font>.\n\nЯ вижу, вы используете одновременно со мной устаревшую версию - <font color='#ff0000'>[WOTC] New Promotion Screen by Default</font>. С ней всё нормально, но вам она уже не нужна.\n\nЯ умею всё, что делал <font color='#ff0000'>[WOTC] New Promotion Screen by Default</font> и многое другое, и я работаю со всеми модами, что его требуют.\n\nРекомендуется отключить или удалить <font color='#ff0000'>[WOTC] New Promotion Screen by Default</font> - я возьму его функции на себя."
+
+[X2EventListener_PromotionScreenOverrides]
+SparkAbilityTreeTitles[0]="Битва будущего"
+SparkAbilityTreeTitles[1]="Боевая машина"
+SparkAbilityTreeTitles[2]="XCOM"

--- a/X2WOTCCommunityPromotionScreen/Localization/XComGame.chn
+++ b/X2WOTCCommunityPromotionScreen/Localization/XComGame.chn
@@ -1,4 +1,0 @@
-[Spark X2SoldierClassTemplate]
-AbilityTreeTitles[0]="未来战斗"
-AbilityTreeTitles[1]="战争机器"
-AbilityTreeTitles[2]="XCOM"

--- a/X2WOTCCommunityPromotionScreen/Localization/XComGame.cht
+++ b/X2WOTCCommunityPromotionScreen/Localization/XComGame.cht
@@ -1,4 +1,0 @@
-[Spark X2SoldierClassTemplate]
-AbilityTreeTitles[0]="未來戰鬥"
-AbilityTreeTitles[1]="戰爭機器"
-AbilityTreeTitles[2]="XCOM"

--- a/X2WOTCCommunityPromotionScreen/Localization/XComGame.deu
+++ b/X2WOTCCommunityPromotionScreen/Localization/XComGame.deu
@@ -1,4 +1,0 @@
-[Spark X2SoldierClassTemplate]
-AbilityTreeTitles[0]="Kampf der Zukunft"
-AbilityTreeTitles[1]="Kriegsmaschine"
-AbilityTreeTitles[2]="XCOM"

--- a/X2WOTCCommunityPromotionScreen/Localization/XComGame.esn
+++ b/X2WOTCCommunityPromotionScreen/Localization/XComGame.esn
@@ -1,4 +1,0 @@
-[Spark X2SoldierClassTemplate]
-AbilityTreeTitles[0]="Combate del futuro"
-AbilityTreeTitles[1]="Máquina de guerra"
-AbilityTreeTitles[2]="XCOM"

--- a/X2WOTCCommunityPromotionScreen/Localization/XComGame.fra
+++ b/X2WOTCCommunityPromotionScreen/Localization/XComGame.fra
@@ -1,4 +1,0 @@
-[Spark X2SoldierClassTemplate]
-AbilityTreeTitles[0]="Combat du futur"
-AbilityTreeTitles[1]="Machine de guerre"
-AbilityTreeTitles[2]="XCOM"

--- a/X2WOTCCommunityPromotionScreen/Localization/XComGame.int
+++ b/X2WOTCCommunityPromotionScreen/Localization/XComGame.int
@@ -1,4 +1,0 @@
-[Spark X2SoldierClassTemplate]
-AbilityTreeTitles[0]="Future Combat"
-AbilityTreeTitles[1]="War Machine"
-AbilityTreeTitles[2]="XCOM"

--- a/X2WOTCCommunityPromotionScreen/Localization/XComGame.ita
+++ b/X2WOTCCommunityPromotionScreen/Localization/XComGame.ita
@@ -1,4 +1,0 @@
-[Spark X2SoldierClassTemplate]
-AbilityTreeTitles[0]="Guerra del futuro"
-AbilityTreeTitles[1]="Macchina da guerra"
-AbilityTreeTitles[2]="XCOM"

--- a/X2WOTCCommunityPromotionScreen/Localization/XComGame.jpn
+++ b/X2WOTCCommunityPromotionScreen/Localization/XComGame.jpn
@@ -1,4 +1,0 @@
-[Spark X2SoldierClassTemplate]
-AbilityTreeTitles[0]="未来の戦闘"
-AbilityTreeTitles[1]="ウォー・マシーン"
-AbilityTreeTitles[2]="XCOM"

--- a/X2WOTCCommunityPromotionScreen/Localization/XComGame.kor
+++ b/X2WOTCCommunityPromotionScreen/Localization/XComGame.kor
@@ -1,4 +1,0 @@
-[Spark X2SoldierClassTemplate]
-AbilityTreeTitles[0]="미래 전투"
-AbilityTreeTitles[1]="워머신"
-AbilityTreeTitles[2]="XCOM"

--- a/X2WOTCCommunityPromotionScreen/Localization/XComGame.pol
+++ b/X2WOTCCommunityPromotionScreen/Localization/XComGame.pol
@@ -1,4 +1,0 @@
-[Spark X2SoldierClassTemplate]
-AbilityTreeTitles[0]="Walka przyszłości"
-AbilityTreeTitles[1]="Machina bojowa"
-AbilityTreeTitles[2]="XCOM"

--- a/X2WOTCCommunityPromotionScreen/Localization/XComGame.rus
+++ b/X2WOTCCommunityPromotionScreen/Localization/XComGame.rus
@@ -1,4 +1,0 @@
-[Spark X2SoldierClassTemplate]
-AbilityTreeTitles[0]="Битва будущего"
-AbilityTreeTitles[1]="Боевая машина"
-AbilityTreeTitles[2]="XCOM"

--- a/X2WOTCCommunityPromotionScreen/Src/X2WOTCCommunityPromotionScreen/Classes/X2EventListener_PromotionScreenOverrides.uc
+++ b/X2WOTCCommunityPromotionScreen/Src/X2WOTCCommunityPromotionScreen/Classes/X2EventListener_PromotionScreenOverrides.uc
@@ -6,6 +6,11 @@
 //---------------------------------------------------------------------------------------
 class X2EventListener_PromotionScreenOverrides extends X2EventListener config(PromotionUIMod);
 
+// Issue #44
+// The SPARK ability tree titles to use if no other mod has set
+// them (since the base game doesn't provide any itself).
+var localized array<string> SparkAbilityTreeTitles;
+
 static function array<X2DataTemplate> CreateTemplates()
 {
 	local array<X2DataTemplate> Templates;
@@ -25,74 +30,106 @@ static function CHEventListenerTemplate CreateListeners()
 	// they can do so even with default priority.
 	Template.AddCHEvent('OverridePromotionBlueprintTagPrefix', OverridePromotionBlueprintTagPrefix, ELD_Immediate, 40);
 	Template.AddCHEvent('OverridePromotionUIClass', OverridePromotionUIClass, ELD_Immediate, 40);
+	Template.AddCHEvent('OverrideLocalizedAbilityTreeTitle', FixSparkAbilityTitles, ELD_Immediate, 30);
 	Template.RegisterInStrategy = true;
 
 	return Template;
 }
 
 static function EventListenerReturn OverridePromotionBlueprintTagPrefix(
-    Object EventData,
-    Object EventSource,
-    XComGameState GameState,
-    Name InEventID,
-    Object CallbackData)
+	Object EventData,
+	Object EventSource,
+	XComGameState GameState,
+	Name InEventID,
+	Object CallbackData)
 {
 	local XComLWTuple Tuple;
 	local XComGameState_Unit UnitState;
 	local UIAfterAction AfterActionScreen;
 
 	Tuple = XComLWTuple(EventData);
-    if (Tuple == none)
-    {
-        return ELR_NoInterrupt;
-    }
+	if (Tuple == none)
+	{
+		return ELR_NoInterrupt;
+	}
 
 	UnitState = XComGameState_Unit(Tuple.Data[0].o);
 	if (UnitState == none)
 	{
 		return ELR_NoInterrupt;
-    }
+	}
 
-    AfterActionScreen = UIAfterAction(EventSource);
+	AfterActionScreen = UIAfterAction(EventSource);
 	if (AfterActionScreen == none)
 	{
 		return ELR_NoInterrupt;
-    }
+	}
 
 	// CPS will change the soldier's position on the promotion screen, unless they are a psi operative.
-    if (!UnitState.IsPsiOperative())
-    {
-        Tuple.Data[1].s = UnitState.IsGravelyInjured() ?
-                AfterActionScreen.UIBlueprint_PrefixHero_Wounded :
-                AfterActionScreen.UIBlueprint_PrefixHero;
-    }
+	if (!UnitState.IsPsiOperative())
+	{
+		Tuple.Data[1].s = UnitState.IsGravelyInjured() ?
+				AfterActionScreen.UIBlueprint_PrefixHero_Wounded :
+				AfterActionScreen.UIBlueprint_PrefixHero;
+	}
 
-    return ELR_NoInterrupt;
+	return ELR_NoInterrupt;
 }
 
 static function EventListenerReturn OverridePromotionUIClass(
-    Object EventData,
-    Object EventSource,
-    XComGameState GameState,
-    Name InEventID,
-    Object CallbackData)
+	Object EventData,
+	Object EventSource,
+	XComGameState GameState,
+	Name InEventID,
+	Object CallbackData)
 {
-    local XComLWTuple Tuple;
-    local CHLPromotionScreenType ScreenType;
+	local XComLWTuple Tuple;
+	local CHLPromotionScreenType ScreenType;
 
 	Tuple = XComLWTuple(EventData);
-    if (Tuple == none)
-    {
-        return ELR_NoInterrupt;
-    }
+	if (Tuple == none)
+	{
+		return ELR_NoInterrupt;
+	}
 
-    ScreenType = CHLPromotionScreenType(Tuple.Data[0].i);
+	ScreenType = CHLPromotionScreenType(Tuple.Data[0].i);
 
 	// CPS will always replace standard and hero promotion screens.
-    if (ScreenType == eCHLPST_Hero || ScreenType == eCHLPST_Standard)
-    {
-        Tuple.Data[1].o = class'X2WOTCCommunityPromotionScreen.CPS_UIArmory_PromotionHero';
-    }
+	if (ScreenType == eCHLPST_Hero || ScreenType == eCHLPST_Standard)
+	{
+		Tuple.Data[1].o = class'X2WOTCCommunityPromotionScreen.CPS_UIArmory_PromotionHero';
+	}
 
-    return ELR_NoInterrupt;
+	return ELR_NoInterrupt;
+}
+
+// Issue #44: Add ability tree titles for SPARKs if there aren't any set up yet
+static function EventListenerReturn FixSparkAbilityTitles(
+	Object EventData,
+	Object EventSource,
+	XComGameState GameState,
+	Name InEventID,
+	Object CallbackData)
+{
+	local XComGameState_Unit UnitState;
+	local XComLWTuple Tuple;
+	local int Row, i;
+
+	Tuple = XComLWTuple(EventData);
+	if (Tuple == none)
+		return ELR_NoInterrupt;
+
+	UnitState = XComGameState_Unit(EventSource);
+	if (UnitState == none)
+		return ELR_NoInterrupt;
+
+	Row = Tuple.Data[0].i;
+
+	if (UnitState.GetSoldierClassTemplateName() == 'Spark' &&
+		UnitState.GetSoldierClassTemplate().AbilityTreeTitles.Length == 0)
+	{
+		Tuple.Data[1].s = default.SparkAbilityTreeTitles[Row];
+	}
+
+	return ELR_NoInterrupt;
 }


### PR DESCRIPTION
Placing the default SPARK ability tree titles into the localisation files makes it difficult to override them in other mods. Now, CPS sets
those tree titles in an 'OverrideLocalizedAbilityTreeTitle' listener and *only* sets values if none are already configured.

Fixes #44.