### PR TITLE
Compatibility with View Locked Skills - Wotc

### DIFF
--- a/X2WOTCCommunityPromotionScreen/ReadMe.txt
+++ b/X2WOTCCommunityPromotionScreen/ReadMe.txt
@@ -7,7 +7,8 @@ It replaces the standard soldier promotion screen with a modified version of the
 [list]
 [*] Added [b][url=https://steamcommunity.com/sharedfiles/filedetails/?id=667104300]Mod Config Menu[/url][/b] support.
 [*] Ability tagging - while on the promotion screen, you can click locked abilities to tag them. This is mostly useful for planning out soldiers' ability trees or marking important abilities so you don't forget to unlock them later. This feature is disabled by default, and needs to be enabled in Mod Config Menu. "Show perks from unreached ranks" setting must be enabled as well. Basic tagging mode simply marks abilities with an icon. Advanced mode will also display order numbers to indicate the sequence or priority in which you should unlock the abilities.
-[*] Added and documented multiple events for other mods to interact with.[/list]
+[*] Added and documented multiple events for other mods to interact with.
+[/list]
 
 [h1]Improvements[/h1]
 [list]
@@ -17,13 +18,16 @@ It replaces the standard soldier promotion screen with a modified version of the
 [*] "More info" yellow question mark icon will be shown for all revealed abilities.
 [*] Support mutually exclusive abilities setup on ability templates.
 [*] Bugfix: scrollbar no longer gets misplaced when in windowed mode.
-[*] Bugfix: "promotion available" banner no longer displays if the soldier can't actually unlock any new perks.[/list]
+[*] Bugfix: "promotion available" banner no longer displays if the soldier can't actually unlock any new perks.
+[/list]
 
 [h1]Compatibility[/h1]
 [list]
 [*] All mods that require [b]New Promotion Screen By Default[/b] can be used with the [b]Community Promotion Screen[/b] instead. Alternative Mod Launcher will warn you about a missing dependency, but it can be safely ignored in this case.
 [*] Community Promotion Screen can be used together with [b]New Promotion Screen By Default[/b], but then the [b]New Promotion Screen By Default[/b] will be simply quietly disabled and will not do anything. You will also see an in-game warning popup saying that.
-[*] Community Promotion Screen is [b][i]INCOMPATIBLE[/i][/b] with [url=https://steamcommunity.com/sharedfiles/filedetails/?id=1280477867][b]Musashis RPG Overhaul[/b][/url], as RPGO adds its own promotion screen.[/list]
+[*] Community Promotion Screen is [b][i]INCOMPATIBLE[/i][/b] with [url=https://steamcommunity.com/sharedfiles/filedetails/?id=1280477867][b]Musashis RPG Overhaul[/b][/url], as RPGO adds its own promotion screen.
+[*] [b][url=https://steamcommunity.com/sharedfiles/filedetails/?id=1130817270]View Locked Skills - Wotc[/url][/b] - Community Promotion Screen already has a "show perks from unreached ranks" MCM setting, but we took some measures so that these mods can coexist without stepping on each other's toes.
+[/list]
 
 [h1]Contributing to the project[/h1]
 

--- a/X2WOTCCommunityPromotionScreen/Src/X2WOTCCommunityPromotionScreen/Classes/CPS_MCM_Screen.uc
+++ b/X2WOTCCommunityPromotionScreen/Src/X2WOTCCommunityPromotionScreen/Classes/CPS_MCM_Screen.uc
@@ -91,6 +91,9 @@ simulated function SaveButtonClicked(MCM_API_SettingsPage Page)
 
 	VERSION_CFG = `MCM_CH_GetCompositeVersion();
 	SaveConfig();
+
+	// Issue #62
+	class'X2DownloadableContentInfo_X2WOTCCommunityPromotionScreen'.static.Update_ViewLockedSkills_UISL();
 }
 
 

--- a/X2WOTCCommunityPromotionScreen/Src/X2WOTCCommunityPromotionScreen/Classes/X2DownloadableContentInfo_X2WOTCCommunityPromotionScreen.uc
+++ b/X2WOTCCommunityPromotionScreen/Src/X2WOTCCommunityPromotionScreen/Classes/X2DownloadableContentInfo_X2WOTCCommunityPromotionScreen.uc
@@ -1,5 +1,7 @@
 class X2DownloadableContentInfo_X2WOTCCommunityPromotionScreen extends X2DownloadableContentInfo;
 
+`include(X2WOTCCommunityPromotionScreen\Src\ModConfigMenuAPI\MCM_API_CfgHelpers.uci)
+
 static event OnPostTemplatesCreated()
 {
 	// Issue #25
@@ -53,6 +55,9 @@ static function OnPreCreateTemplates()
 {
     // Issue #26
 	Neuter_NPSBD_UISL();
+
+	// Issue #62
+	Update_ViewLockedSkills_UISL();
 }
 
 // Start Issue #26
@@ -67,3 +72,30 @@ static final function Neuter_NPSBD_UISL()
     }
 }
 // End Issue #26
+
+// Start Issue #62
+/// This handles CPS' compatibility with View Locked Skills - Wotc
+/// https://steamcommunity.com/sharedfiles/filedetails/?id=1130817270
+/// When CPS is configured to show perks from unreached ranks via MCM, 
+/// View Locked Skills' UISL is neutered.
+/// The UISL is un-neutered if Show Unreached Perks is disabled.
+/// This allows both mods to coexist without stepping on each other's toes too much,
+/// even though View Locked Skills is mostly redundant with CPS.
+static final function Update_ViewLockedSkills_UISL()
+{
+	local UIScreenListener CDO;
+
+	CDO = UIScreenListener(class'XComEngine'.static.GetClassDefaultObjectByName('Main_ViewLockedSkillsWotc'));
+	if (CDO != none)
+	{	
+		if (`GETMCMVAR(SHOW_UNREACHED_PERKS))
+		{
+			CDO.ScreenClass = class'UIScreen_Dummy';
+		}
+		else if (CDO.ScreenClass == class'UIScreen_Dummy')
+		{
+			CDO.ScreenClass = none;
+		}
+	}
+}
+// End Issue #62


### PR DESCRIPTION
Fixes #62

When "Show perks from unreached ranks" MCM setting is enabled, CPS neuters the View Locked Skills' UISL so it doesn't interfere with ability tagging. 

When the setting is disabled, the UISL is un-neutered.